### PR TITLE
Change command to generate beeper.h in correct folder

### DIFF
--- a/docs/tutorial-cap10.md
+++ b/docs/tutorial-cap10.md
@@ -98,7 +98,7 @@ Marcamos `Assembly` e `Include player code` y pulsamos `Compile`. Grabamos el ar
 Al igual que pasaba con la música de Beepola, el código que exporta BeepFX no nos sirve directamente, sino que habrá que pasarlo por la turmix. Suponiendo que tengamos el archivo guardado como `mus/dogmole_fx.asm`, nos vamos a `/dev` y ejecutamos así el conversor:
 
 ```
-    $ ..\utils\asm2z88dk.exe ..\mus\dogmole_fx.asm beeper.h mk1
+    $ ..\utils\asm2z88dk.exe ..\mus\dogmole_fx.asm sound\beeper.h mk1
 ```
 
 Pero todavía no es suficiente, ya que necesitamos una interfaz con **MTE MK1**, una función en C que reciba un parámetro, lo cocine, y llame al _player_ de efectos de BeepFx. Editamos `beeper.h` y añadimos este código al final, que hace precisamente eso:

--- a/docs/tutorial-cap10.md
+++ b/docs/tutorial-cap10.md
@@ -101,7 +101,7 @@ Al igual que pasaba con la música de Beepola, el código que exporta BeepFX no 
     $ ..\utils\asm2z88dk.exe ..\mus\dogmole_fx.asm sound\beeper.h mk1
 ```
 
-Pero todavía no es suficiente, ya que necesitamos una interfaz con **MTE MK1**, una función en C que reciba un parámetro, lo cocine, y llame al _player_ de efectos de BeepFx. Editamos `beeper.h` y añadimos este código al final, que hace precisamente eso:
+Pero todavía no es suficiente, ya que necesitamos una interfaz con **MTE MK1**, una función en C que reciba un parámetro, lo cocine, y llame al _player_ de efectos de BeepFx. Editamos `beeper.h` que está en la carpeta sound y añadimos este código al final, que hace precisamente eso:
 
 ```c
 


### PR DESCRIPTION
Siguiendo la documentación al ejecutar el comando para generar el beeper.h tal como esta te lo genera en la carpeta dev y tienes que moverlo a sound pero la doc no dice nada, he modificado el comando para que te lo cree en el sitio y especificado la carpeta cuando dice que tienes que añadir la función al final